### PR TITLE
Application.mk for release build

### DIFF
--- a/Native_VA_SDK/jni/Application.mk
+++ b/Native_VA_SDK/jni/Application.mk
@@ -1,4 +1,6 @@
 APP_ABI := armeabi-v7a
+# Uncomment the line below to your applcation.mk for release build.
+#APP_OPTIM := release
 APP_STL := gnustl_static
 APP_PLATFORM := android-18
 APP_CPPFLAGS := -frtti -fexceptions


### PR DESCRIPTION
It will make NDK build a release version library when adding this option to your application.mk.
Especially for applications that use OpenCV4Android should add this option for better performance.